### PR TITLE
simple handling of rspec "context" blocks

### DIFF
--- a/example/example_code.rb
+++ b/example/example_code.rb
@@ -12,13 +12,17 @@ end
 # Specs
 # 
 describe String do
-  describe '#pig_latin' do
-    it "should be a pig!" do
-      "hello".pig_latin.should == "ellohay"
-     end
+  context 'monkey patch for pig latin' do
 
-    it "should fail to be a pig!" do
-      "hello".pig_latin.should == "hello"
+    describe '#pig_latin' do
+      it "should be a pig!" do
+        "hello".pig_latin.should == "ellohay"
+      end
+
+      it "should fail to be a pig!" do
+        "hello".pig_latin.should == "hello"
+      end
+      
     end
   end
 end

--- a/lib/yard-rspec/handler.rb
+++ b/lib/yard-rspec/handler.rb
@@ -31,11 +31,17 @@ class RSpecItHandler < YARD::Handlers::Ruby::Base
     obj = P(owner[:spec])
     return if obj.is_a?(Proxy)
     
-    (obj[:specifications] ||= []) << {
-      name: statement.parameters.first.jump(:string_content).source,
-      file: statement.file,
-      line: statement.line,
-      source: statement.last.last.source.chomp
-    }
+    specs = (obj[:specifications] ||= [])
+    
+    name = statement.parameters.first.jump(:string_content).source
+    
+    unless specs.find{ |spec| spec[:name] == name }    
+      (obj[:specifications] ||= []) << {
+        name: statement.parameters.first.jump(:string_content).source,
+        file: statement.file,
+        line: statement.line,
+        source: statement.last.last.source.chomp
+      }
+    end
   end
 end

--- a/lib/yard-rspec/handler.rb
+++ b/lib/yard-rspec/handler.rb
@@ -37,7 +37,7 @@ class RSpecItHandler < YARD::Handlers::Ruby::Base
     
     unless specs.find{ |spec| spec[:name] == name }    
       (obj[:specifications] ||= []) << {
-        name: statement.parameters.first.jump(:string_content).source,
+        name: name,
         file: statement.file,
         line: statement.line,
         source: statement.last.last.source.chomp

--- a/lib/yard-rspec/handler.rb
+++ b/lib/yard-rspec/handler.rb
@@ -14,6 +14,15 @@ class RSpecDescribeHandler < YARD::Handlers::Ruby::Base
   end
 end
 
+class RSpecContextHandler < YARD::Handlers::Ruby::Base
+  handles method_call(:context)
+  
+  def process
+    parse_block(statement.last.last, owner: owner)
+  rescue YARD::Handlers::NamespaceMissingError
+  end
+end
+
 class RSpecItHandler < YARD::Handlers::Ruby::Base
   handles method_call(:it)
   


### PR DESCRIPTION
Your plugin is really cool, but it wasn't working for me because I use rspec's "context" feature extensively. I just use it to group tests together into organizational units, so I simply updated the new-style handler (not the legacy one) to parse "context" blocks without doing anything else. I also updated the example so you can see the case I needed to handle.

I'm not sure how appropriate this change is for the wider audience. It might be my personal style that I don't use "context" the same as "describe", but I believe I'm following rspec conventions. If some people want to use "context" like "describe", perhaps some conventions could be established to indicate to the plugin when text is purely explanatory vs actually describing a class or method (maybe by using known prefixes in the string argument, like '.' , '#' , and '::').

PS - have you ever used "example groups" in rspec? I use them in a couple places and I'm interested to get it working with this plugin, but it seems like it will be pretty difficult to implement.
