### PR TITLE
Support more spec organizations and 1.8.6 fix

### DIFF
--- a/example/example_code.rb
+++ b/example/example_code.rb
@@ -1,10 +1,9 @@
-# Run `yardoc -e ../lib/yard-rspec example_code.rb`
-
+# Run `yardoc -e ./lib/yard-rspec.rb ./example/example_code.rb`
 
 class String
   # Pig latin of a String
-  def pig_latin
-    self[1..-1] + self[0] + "ay"
+  def pig_latin(switch = true)
+    "#{self[1..-1]}#{self[0, 1]}ay"
   end
 end
 
@@ -15,10 +14,31 @@ describe String do
   describe '#pig_latin' do
     it "should be a pig!" do
       "hello".pig_latin.should == "ellohay"
-     end
+    end
 
-    it "should fail to be a pig!" do
-      "hello".pig_latin.should == "hello"
+    context "on an empty string" do
+      it "should fail to be a pig!" do
+        "".pig_latin.should == ""
+      end
+    end
+
+    it "works with RSpec metadata", :see => "yep" do
+      "xyz".pig_latin.length.should == "xyz".length + 2
+    end
+
+    it "works on multi-lingual strings" # pending
+  end
+
+  context "under circumstances" do
+    describe "#pig_latin(true)" do
+      subject { %w(i can count on you).map(&:pig_latin).join(" ") }
+
+      its(:length) { should == 28 }
+      its(:"length") { should == 28 }
+      its('length') { should == 28 }
+      its "length" do; should == 28 end
+
+      specify { should == "iay ancay ountcay onay ouyay" }
     end
   end
 end

--- a/lib/yard-rspec/handler.rb
+++ b/lib/yard-rspec/handler.rb
@@ -2,31 +2,108 @@ class RSpecDescribeHandler < YARD::Handlers::Ruby::Base
   handles method_call(:describe)
   
   def process
-    objname = statement.parameters.first.jump(:string_content).source
-    if statement.parameters[1]
-      src = statement.parameters[1].jump(:string_content).source
-      objname += (src[0] == "#" ? "" : "::") + src
+    describes = statement.parameters.first.jump(:string_content).source
+
+    # Remove the argument list from describe "#method(a, b, &c)"
+    if arguments = describes[/[#.](?:.+)(\([^)]*\))$/, 1]
+      describes = describes[0, describes.length - arguments.length]
     end
-    obj = {:spec => owner ? (owner[:spec] || "") : ""}
-    obj[:spec] += objname
-    parse_block(statement.last.last, owner: obj)
+
+    unless owner.is_a?(Hash)
+      pwner = Hash[describes: describes, context: ""]
+      parse_block(statement.last.last, owner: pwner)
+    else
+      describes = owner[:describes] + describes
+      pwner = owner.merge(describes: describes)
+      parse_block(statement.last.last, owner: pwner)
+    end
+  rescue YARD::Handlers::NamespaceMissingError
+  end
+end
+
+class RSpecContextHandler < YARD::Handlers::Ruby::Base
+  handles method_call(:context)
+
+  def process
+    if owner.is_a?(Hash)
+      context = statement.parameters.first.jump(:string_content).source
+      context = owner[:context] + context + " "
+
+      parse_block(statement.last.last, owner: owner.merge(context: context))
+    end
   rescue YARD::Handlers::NamespaceMissingError
   end
 end
 
 class RSpecItHandler < YARD::Handlers::Ruby::Base
   handles method_call(:it)
+  handles method_call(:specify)
   
   def process
-    return if owner.nil?
-    obj = P(owner[:spec])
-    return if obj.is_a?(Proxy)
-    
-    (obj[:specifications] ||= []) << {
-      name: statement.parameters.first.jump(:string_content).source,
-      file: statement.file,
-      line: statement.line,
-      source: statement.last.last.source.chomp
-    }
+    return unless owner.is_a?(Hash)
+    return unless owner[:describes]
+
+    node = YARD::Registry.resolve(nil, owner[:describes], true)
+    spec = if statement.parameters
+             statement.parameters.first.jump(:string_content).source
+           else
+             "untitled spec"
+           end
+
+    unless node
+      log.warn "Unknown node #{owner[:describes]} for spec defined in #{statement.file} near line #{statement.line}"
+      # statement.file
+      # statement.line
+      # owner[:describes]
+      return
+    end
+
+    if last = statement.last.last
+      source = last.source.strip
+    else
+      source = ""
+    end
+
+    (node[:specifications] ||= []) << \
+      Hash[ name: owner[:context] + spec,
+            file: statement.file,
+            line: statement.line,
+            source: source ]
+  end
+end
+
+class RSpecItsHandler < YARD::Handlers::Ruby::Base
+  handles method_call(:its)
+  
+  def process
+    return unless owner.is_a?(Hash)
+    return unless owner[:describes]
+
+    node = YARD::Registry.resolve(nil, owner[:describes], true)
+    property = statement.parameters.first.join(" ")
+    should   = statement.last.last.source[/should(?:_not)? (.+)/, 1]
+
+    spec = if property and should
+             spec = "#{property} #{should}"
+           else
+             "untitled spec"
+           end
+
+    unless node
+      log.warn "Unknown node #{owner[:describes]} for spec defined in #{statement.file} near line #{statement.line}"
+      return
+    end
+
+    if last = statement.last.last
+      source = last.source.strip
+    else
+      source = ""
+    end
+
+    (node[:specifications] ||= []) << \
+      Hash[ name: owner[:context] + spec,
+            file: statement.file,
+            line: statement.line,
+            source: source ]
   end
 end

--- a/lib/yard-rspec/legacy.rb
+++ b/lib/yard-rspec/legacy.rb
@@ -1,31 +1,102 @@
 class LegacyRSpecDescribeHandler < YARD::Handlers::Ruby::Legacy::Base
-  MATCH = /\Adescribe\s+(.+?)\s+(do|\{)/
+  MATCH = /\Adescribe\s+(.+)\s+(?:do|\{)/
   handles MATCH
   
   def process
-    objname = statement.tokens.to_s[MATCH, 1].gsub(/["']/, '')
-    obj = {:spec => owner ? (owner[:spec] || "") : ""}
-    obj[:spec] += objname
-    parse_block :owner => obj
+    describes = statement.tokens.to_s[MATCH, 1].gsub(/["']/, "")
+
+    # Remove the argument list from describe "#method(a, b, &c)"
+    if arguments = describes[/[#.](?:.+?)(\([^)]*\))$/, 1]
+      describes = describes[0, describes.length - arguments.length]
+    end
+
+    unless owner.is_a?(Hash)
+      pwner = Hash[:describes => describes, :context => ""]
+      parse_block(:owner => pwner)
+    else
+      describes = owner[:describes] + describes
+      pwner = owner.merge(:describes => describes)
+      parse_block(:owner => pwner)
+    end
   rescue YARD::Handlers::NamespaceMissingError
   end
 end
 
-class LegacyRSpecItHandler < YARD::Handlers::Ruby::Legacy::Base
-  MATCH = /\Ait\s+['"](.+?)['"]\s+(do|\{)/
+class LegacySpecContextHandler < YARD::Handlers::Ruby::Legacy::Base
+  MATCH = /\Acontext\s+(['"])(.+)\1(?:.*?)\s+(?:do|\{)/
   handles MATCH
-  
+
   def process
-    return if owner.nil?
-    obj = P(owner[:spec])
-    return if obj.is_a?(Proxy)
-    
-    (obj[:specifications] ||= []) << {
-      :name => statement.tokens.to_s[MATCH, 1],
-      :file => parser.file,
-      :line => statement.line,
-      :source => statement.block.to_s
-    }
+    if owner.is_a?(Hash)
+      context = statement.tokens.to_s[MATCH, 2]
+      context = owner[:context] + context + " "
+
+      parse_block(:owner => owner.merge(:context => context))
+    end
   end
 end
 
+class LegacyRSpecItHandler < YARD::Handlers::Ruby::Legacy::Base
+  MATCH = /\A(?:it|specify)\s+(['"])(.+?)\1.*?(?:(\s+(?:do|\{))|$)/
+
+  handles MATCH
+  handles /\A(?:it|specify)\s+.*?(?:do|\{)/
+  
+  def process
+    return unless owner.is_a?(Hash)
+    return unless owner[:describes]
+
+    node = YARD::Registry.resolve(nil, owner[:describes], true)
+    spec = statement.tokens.to_s[MATCH, 2] || "untitled spec"
+
+    unless node
+      log.warn "Unknown node #{owner[:describes]} for spec defined in #{parser.file} near line #{statement.line}"
+      return
+    end
+
+    source = statement.block.to_s.strip
+
+    (node[:specifications] ||= []) << \
+      Hash[ :name => owner[:context] + spec,
+            :file => parser.file,
+            :line => statement.line,
+            :source => source ]
+  end
+end
+
+class LegacyRSpecItsHandler < YARD::Handlers::Ruby::Legacy::Base
+# MATCH = /\Aits\s*(\(?)\s*[:]?(['"]?)(.+)\2\1(?:(\s+(?:do|\{))|$)/
+# handles MATCH
+
+  MATCH = /\Aits\s*([(]?)\s*:?(['"]?)([^'")]+)\2/
+  handles MATCH
+
+  def process
+    return unless owner.is_a?(Hash)
+    return unless owner[:describes]
+
+    node = YARD::Registry.resolve(nil, owner[:describes], true)
+
+    property = statement.tokens.to_s[MATCH, 3]
+    should   = statement.block.to_s[/should(?:_not)?\s+(.+)/, 1]
+
+    spec = if property and should
+             "#{property} #{should}"
+           else
+             "untitled spec"
+           end
+
+    unless node
+      log.warn "Unknown node #{owner[:describes]} for spec defined in #{parser.file} near line #{statement.line}"
+      return
+    end
+
+    source = statement.block.to_s.strip
+
+    (node[:specifications] ||= []) << \
+      Hash[ :name => owner[:context] + spec,
+            :file => parser.file,
+            :line => statement.line,
+            :source => source ]
+  end
+end

--- a/templates/default/method_details/html/specs.erb
+++ b/templates/default/method_details/html/specs.erb
@@ -10,13 +10,11 @@
               <td>
                 <pre class="lines">
 
-
-<%= spec[:source].split("\n").size.times.to_a.map {|i| spec[:line] + i }.join("\n") %></pre>
+<%= (1..spec[:source].split("\n").size).map {|i| spec[:line] + i }.join("\n") %></pre>
               </td>
               <td>
                 <pre class="code"><span class="info file"># File '<%= h spec[:file] %>', line <%= spec[:line] %></span>
-
-<%= html_syntax_highlight format_source(spec[:source]) %></pre>
+<% if spec[:source] =~ /\S/ %><%= html_syntax_highlight format_source(spec[:source]) %></pre><% end %>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
I've fixed the template issue so everything is 1.8.6-compatible.  I've also extended the parsers (both 1.8 and 1.9 versions) to support a wider number of specs.  This change is not compatible with the two forks that also extend the parsers to support "context" and friends, but I believe it is more complete and possibly can accommodate both use cases.

This patch adds support for pending specs, nested contexts, nested describes, argument lists in the method description, and default spec titles for unnamed specs (both in 1.8 and 1.9).

Closes #1
Closes #2
