### PR TITLE
Fixes code positioning when rendered in HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 .yardoc
-
+doc

--- a/example/example_code.rb
+++ b/example/example_code.rb
@@ -8,17 +8,33 @@ class String
   end
 end
 
-# 
+#
 # Specs
-# 
+#
 describe String do
   describe '#pig_latin' do
     it "should be a pig!" do
-      "hello".pig_latin.should == "ellohay"
+      expect("hello".pig_latin).to eq("ellohay")
      end
 
     it "should fail to be a pig!" do
-      "hello".pig_latin.should == "hello"
+      expect("hello".pig_latin).not_to eq("hello")
+    end
+  end
+
+  describe 'Some context' do
+    describe '#pig_latin' do
+      it 'should still be a pig!' do
+        expect("food".pig_latin).to eq('oodfay')
+      end
+    end
+  end
+
+  describe '#pig_latin' do
+    context 'Some other context' do
+      it 'should still be a pig in some other context!' do
+        expect("avocado".pig_latin).to eq('vocadoaay')
+      end
     end
   end
 end

--- a/lib/yard-rspec.rb
+++ b/lib/yard-rspec.rb
@@ -1,3 +1,4 @@
 YARD::Templates::Engine.register_template_path File.dirname(__FILE__) + '/../templates'
+require File.join(File.dirname(__FILE__), 'yard-rspec', 'templates/helpers/html_helper')
 require File.join(File.dirname(__FILE__), 'yard-rspec', 'handler') if RUBY19
 require File.join(File.dirname(__FILE__), 'yard-rspec', 'legacy')

--- a/lib/yard-rspec/handler.rb
+++ b/lib/yard-rspec/handler.rb
@@ -1,14 +1,18 @@
 class RSpecDescribeHandler < YARD::Handlers::Ruby::Base
   handles method_call(:describe)
-  
+  handles method_call(:context)
+
   def process
     objname = statement.parameters.first.jump(:string_content).source
+
     if statement.parameters[1]
       src = statement.parameters[1].jump(:string_content).source
       objname += (src[0] == "#" ? "" : "::") + src
     end
     obj = {:spec => owner ? (owner[:spec] || "") : ""}
-    obj[:spec] += objname
+    if statement.parameters.first.jump(:var_ref).type == :var_ref || objname.start_with?("#")
+      obj[:spec] += objname
+    end
     parse_block(statement.last.last, owner: obj)
   rescue YARD::Handlers::NamespaceMissingError
   end
@@ -16,12 +20,12 @@ end
 
 class RSpecItHandler < YARD::Handlers::Ruby::Base
   handles method_call(:it)
-  
+
   def process
     return if owner.nil?
     obj = P(owner[:spec])
     return if obj.is_a?(Proxy)
-    
+
     (obj[:specifications] ||= []) << {
       name: statement.parameters.first.jump(:string_content).source,
       file: statement.file,

--- a/lib/yard-rspec/templates/helpers/html_helper.rb
+++ b/lib/yard-rspec/templates/helpers/html_helper.rb
@@ -1,0 +1,22 @@
+module YARD
+  module Templates::Helpers
+    module HtmlHelper
+      def unindent(str)
+        indent_size = str.split("\n").map do |line|
+          line = untab(line)
+          white_span = line[/\A(\s+)/]
+
+          white_span.nil? ? nil : white_span.size
+        end.compact.min
+
+        str.gsub(/^( ){#{indent_size}}/, '')
+      end
+
+      def untab(str, tab_size = 2)
+        tab_space = 2
+
+        str.gsub("\t", " " * tab_space)
+      end
+    end
+  end
+end

--- a/templates/default/fulldoc/html/css/common.css
+++ b/templates/default/fulldoc/html/css/common.css
@@ -1,0 +1,4 @@
+.test_code {
+  font-size: 13px;
+  line-height: normal;
+}

--- a/templates/default/fulldoc/html/css/common.css
+++ b/templates/default/fulldoc/html/css/common.css
@@ -2,3 +2,6 @@
   font-size: 13px;
   line-height: normal;
 }
+.showSource {
+  font-size: 13px;
+}

--- a/templates/default/method_details/html/specs.erb
+++ b/templates/default/method_details/html/specs.erb
@@ -1,26 +1,20 @@
 <% if object[:specifications] %>
 <div class="tags">
-  <h3>Specifications:</h3>
+  <p class="tag_title">Specifications:</p>
   <ul class="specs">
     <% for spec in object[:specifications] %>
-      <li><%= spec[:name] %>
-        <div class="source_code">
-          <table>
-            <tr>
-              <td>
-                <pre class="lines">
-
-
-<%= spec[:source].split("\n").size.times.to_a.map {|i| spec[:line] + i }.join("\n") %></pre>
-              </td>
-              <td>
-                <pre class="code"><span class="info file"># File '<%= h spec[:file] %>', line <%= spec[:line] %></span>
-
-<%= html_syntax_highlight format_source(spec[:source]) %></pre>
-              </td>
-            </tr>
-          </table>
-        </div>
+      <li>
+        <%=h spec[:name] %>
+        <table class="source_code test_code">
+          <tr>
+            <td>
+              <pre class="lines"><%= "\n\n\n" %><%= spec[:source].split("\n").size.times.to_a.map {|i| spec[:line] + i }.join("\n") %></pre>
+            </td>
+            <td>
+              <pre class="code"><span class="info file"># File '<%= h spec[:file] %>', line <%= object.line %></span><%= "\n\n" %><%= html_syntax_highlight(unindent(spec[:source])) %></pre>
+            </td>
+          </tr>
+        </table>
       </li>
     <% end %>
   </ul>

--- a/yard-rspec.gemspec
+++ b/yard-rspec.gemspec
@@ -1,15 +1,14 @@
 SPEC = Gem::Specification.new do |s|
-  s.name          = "yard-rspec"
-  s.summary       = "YARD plugin to list RSpec specifications inside documentation" 
-  s.version       = "0.1"
+  s.name          = "yard-tests-rspec"
+  s.summary       = "YARD plugin to list RSpec specifications inside documentation"
+  s.version       = "0.1.1"
   s.date          = "2009-09-15"
-  s.author        = "Loren Segal"
-  s.email         = "lsegal@soen.ca"
+  s.authors       = ["Loren Segal", "Jesús Burgos"]
+  s.email         = ["lsegal@soen.ca", "jburmac@gmail.com"]
   s.homepage      = "http://yardoc.org"
   s.platform      = Gem::Platform::RUBY
   s.files         = Dir.glob("{example,lib,templates}/**/*") + ['LICENSE', 'README.rdoc', 'Rakefile']
   s.require_paths = ['lib']
   s.has_rdoc      = 'yard'
-  s.rubyforge_project = 'yard-rspec'
-  s.add_dependency 'yard' 
+  s.add_dependency 'yard'
 end


### PR DESCRIPTION
This commit fixes 3 some design issues.

1. The title of different sections has a different font size.
2. The source code of the test examples and the documented method has different font size.
3. The line numbers don't match with the actual source code. This is the most important one.

This is clearer in the images below.

**Before:**
<img width="838" alt="before" src="https://cloud.githubusercontent.com/assets/23031/24071517/11f025c4-0bd4-11e7-9392-202f394decdc.png">

**After:**
<img width="838" alt="after" src="https://cloud.githubusercontent.com/assets/23031/24071494/8e7d322c-0bd3-11e7-875f-cd60d8b253ea.png">

I hope you find this patch useful.