### PR TITLE
Ignore extra layers of test contexts

### DIFF
--- a/example/example_code.rb
+++ b/example/example_code.rb
@@ -8,17 +8,33 @@ class String
   end
 end
 
-# 
+#
 # Specs
-# 
+#
 describe String do
   describe '#pig_latin' do
     it "should be a pig!" do
-      "hello".pig_latin.should == "ellohay"
+      expect("hello".pig_latin).to eq("ellohay")
      end
 
     it "should fail to be a pig!" do
-      "hello".pig_latin.should == "hello"
+      expect("hello".pig_latin).not_to eq("hello")
+    end
+  end
+
+  describe 'Some context' do
+    describe '#pig_latin' do
+      it 'should still be a pig!' do
+        expect("food".pig_latin).to eq('oodfay')
+      end
+    end
+  end
+
+  describe '#pig_latin' do
+    context 'Some other context' do
+      it 'should still be a pig in some other context!' do
+        expect("avocado".pig_latin).to eq('vocadoaay')
+      end
     end
   end
 end

--- a/lib/yard-rspec/handler.rb
+++ b/lib/yard-rspec/handler.rb
@@ -1,14 +1,18 @@
 class RSpecDescribeHandler < YARD::Handlers::Ruby::Base
   handles method_call(:describe)
-  
+  handles method_call(:context)
+
   def process
     objname = statement.parameters.first.jump(:string_content).source
+
     if statement.parameters[1]
       src = statement.parameters[1].jump(:string_content).source
       objname += (src[0] == "#" ? "" : "::") + src
     end
     obj = {:spec => owner ? (owner[:spec] || "") : ""}
-    obj[:spec] += objname
+    if statement.parameters.first.jump(:var_ref).type == :var_ref || objname.start_with?("#")
+      obj[:spec] += objname
+    end
     parse_block(statement.last.last, owner: obj)
   rescue YARD::Handlers::NamespaceMissingError
   end
@@ -16,12 +20,12 @@ end
 
 class RSpecItHandler < YARD::Handlers::Ruby::Base
   handles method_call(:it)
-  
+
   def process
     return if owner.nil?
     obj = P(owner[:spec])
     return if obj.is_a?(Proxy)
-    
+
     (obj[:specifications] ||= []) << {
       name: statement.parameters.first.jump(:string_content).source,
       file: statement.file,


### PR DESCRIPTION
Two changes:

- Handle calls to 'context' just the same way as 'describe'.
- Allow additional intermediate blocks.

Closes #6.

Update: This also updates the tests to the new rspec interface (`expect(...).to ...` instead of `...should...`).